### PR TITLE
feat: 可以输出排序后的节点的详细配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 dist/
 *.exe
 
-.idea
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.exe
 
 .idea/*
+result.yaml

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ Premium|广港|IEPL|02                        	N/A         	N/A
 Premium|广港|IEPL|03                        	2.62MB/s    	333.00ms
 Premium|广港|IEPL|04                        	1.46MB/s    	272.00ms
 Premium|广港|IEPL|05                        	3.87MB/s    	249.00ms
+# 3. 当然你也可以混合使用
+> clash-speedtest -c "https://domain.com/link/hash?clash=1,/home/.config/clash/config.yaml"
 # 3. 使用自定义服务器进行测试（ip地址为示例，并无实际效果）
-> clash-speedtest -c "https://ds-epimetheus.oss-cn-shenzhen.aliyuncs.com/rules" -l "http://1.1.1.1:8080/_down?bytes=%d" --size 10200
+> clash-speedtest -c "https://domain/rules" -l "http://1.1.1.1:8080/_down?bytes=%d" --size 10200
 节点                                            带宽            延迟          
 FORWARD-STEAM-COM                               9.27KB/s        310.00ms    
 FORWARD-STEAM-COM-BAK                           137.41KB/s      68.00ms     

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Usage of clash-speedtest:
         download concurrent size (default 4)
   -f string
         filter proxies by name, use regexp (default ".*")
-  -output string
-        output result to csv file
+  -output yaml / csv
+        output result to csv / yaml file
   -size int
         download size for testing proxies (default 104857600)
   -sort string
@@ -60,6 +60,8 @@ TOKYO-PCCW                                      21.83KB/s       364.00ms
 TW-IEPL-01                                      109.34KB/s      73.00ms     
 USA-GIA                                         14.42KB/s       688.00ms 
 ```
+
+> 当您指定了 `--output yaml` 的时候，会自动将排序后的节点以完整配置输出，方便您编辑自己的节点文件
 
 ## 如何使用自定义服务器进行测速
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"net/url"
+	"os"
+	"testing"
+)
+
+func TestDifferentTypesOfParsing(t *testing.T) {
+	// Create a temporary file
+	tempFile, err := os.CreateTemp("", "test20230815114.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tempFile.Name()) // Clean up
+
+	testCases := []struct {
+		pv        string
+		isUriType bool
+		expectErr bool
+	}{
+		{
+			pv:        "http://example.com",
+			isUriType: true,
+			expectErr: false,
+		},
+		{
+			pv:        "thisisnotavaliduri",
+			isUriType: true,
+			expectErr: true,
+		},
+		{
+			pv:        tempFile.Name(),
+			isUriType: false,
+			expectErr: false,
+		},
+		{
+			pv:        "non_existent_file.txt",
+			isUriType: false,
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		result := DifferentTypesOfParsing(tc.pv, tc.isUriType)
+		if tc.expectErr && result != nil {
+			t.Errorf("Expected error for pv %s, but got no error", tc.pv)
+		}
+		if !tc.isUriType && result != nil {
+			_, ok := result.(os.File)
+			if !ok {
+				t.Errorf("Expected FileInfo type for pv %s", tc.pv)
+			}
+		}
+		if tc.isUriType && result != nil {
+			_, ok := result.(*url.URL)
+			if !ok {
+				t.Errorf("Expected URL type for pv %s", tc.pv)
+			}
+		}
+	}
+}


### PR DESCRIPTION
### 本次的提交内容

1. 修改了 `--output` 参数，当指定为 `csv` 的时候，会正常输出节点的排序和详细延迟情况，当指定为 `yaml` 的时候，会将排序后的节点输出为详细的配置文件
2. 修改了判断成功访问探测 URL 的 StatusCode，2XX都可以算为成功，以兼容 `204` 状态码