### PR TITLE
block proxies by keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Usage of clash-speedtest:
         configuration file path, also support http(s) url
   -f string
         filter proxies by name, use regexp (default ".*")
+  -b string
+        block proxies by keywords, use | to separate multiple keywords (example: -b 'rate|x1|1x')
   -server-url string
         server url for testing proxies (default "https://speed.cloudflare.com")
   -download-size int

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 var (
 	configPathsConfig = flag.String("c", "", "config file path, also support http(s) url")
 	filterRegexConfig = flag.String("f", ".+", "filter proxies by name, use regexp")
+	blockKeywords     = flag.String("b", "", "Use keywords to block nodes. Use vertical bars to separate multiple keywords (for example: -b 'x1|sg|hk')")
 	serverURL         = flag.String("server-url", "https://speed.cloudflare.com", "server url")
 	downloadSize      = flag.Int("download-size", 50*1024*1024, "download size for testing proxies")
 	uploadSize        = flag.Int("upload-size", 20*1024*1024, "upload size for testing proxies")
@@ -52,6 +53,7 @@ func main() {
 	speedTester := speedtester.New(&speedtester.Config{
 		ConfigPaths:      *configPathsConfig,
 		FilterRegex:      *filterRegexConfig,
+		BlockRegex:       *blockKeywords,
 		ServerURL:        *serverURL,
 		DownloadSize:     *downloadSize,
 		UploadSize:       *uploadSize,


### PR DESCRIPTION
屏蔽关键字节点, 实现参考 https://github.com/OP404OP/clash-speedtest  ,有一些比较实用的功能,因此移植过来